### PR TITLE
FIx % sign in comments

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -672,3 +672,13 @@ func TestLoadSGF(t *testing.T) {
 		t.Errorf("Parsed and generated SGF should be the same")		// How safe is this test? Key order is arbitrary in SGF...
 	}
 }
+
+func TestPercentageSignInComment(t *testing.T) {
+	t.Parallel()
+
+	sgfData := "(;C[test%test])"
+	s, _ := LoadSGF(sgfData)
+	if sgfData != s.SGF() {
+		t.Errorf("percentage sign not serialized correctly: %s", s.SGF())
+	}
+}

--- a/io.go
+++ b/io.go
@@ -70,7 +70,7 @@ func (self *Node) write_tree(w io.Writer) {
 
 	node := self
 
-	fmt.Fprintf(w, "(")
+	fmt.Fprint(w, "(")
 
 	for {
 		node.WriteTo(w)

--- a/node.go
+++ b/node.go
@@ -78,7 +78,7 @@ func (self *Node) WriteTo(w io.Writer) (n int64, err error) {
 		}
 	}
 
-	count, err := fmt.Fprintf(w, b.String())
+	count, err := fmt.Fprint(w, b.String())
 	return int64(count), err
 }
 


### PR DESCRIPTION
Converting to SGF has a bug if comments contain the `%` sign.

For example:

```go
func TestPercentageSignInComment(t *testing.T) {
	t.Parallel()

	sgfData := "(;C[test%test])"
	s, _ := LoadSGF(sgfData)
	if sgfData != s.SGF() {
		t.Errorf("percentage sign not serialized correctly: %s", s.SGF())
	}
}
```

Fails with:

```
--- FAIL: TestPercentageSignInComment (0.00s)
    all_test.go:682: percentage sign not serialized correctly: (;C[test%!t(MISSING)est])
```